### PR TITLE
fix the following make error

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -11,7 +11,10 @@ build_requires 'Test::More';
 tests('t/*.t');
 author_tests('xt');
 
-use_test_base;
-auto_include;
-auto_set_repository;
-WriteAll;
+{
+    no strict 'subs';
+    use_test_base;
+    auto_include;
+    auto_set_repository;
+    WriteAll;
+}


### PR DESCRIPTION
/git/p5-test-skip-unlessexistsexecutable$ perl ./Makefile.PL

include /git/p5-test-skip-unlessexistsexecutable/inc/Module/Install.pm Bareword "use_test_base" not allowed while "strict subs" in use at ./Makefile.PL line 14. Execution of ./Makefile.PL aborted due to compilation errors.